### PR TITLE
Wagjamin/easier output

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+# Run manually to reformat a file:
+# clang-format -i --style=file <file>
+Language:        Cpp
+BasedOnStyle:  Google
+---
+Language: Proto
+BasedOnStyle: Google

--- a/file_based_test_driver/alternations.cc
+++ b/file_based_test_driver/alternations.cc
@@ -16,7 +16,7 @@
 #include "file_based_test_driver/alternations.h"
 
 #include "absl/strings/str_join.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 #include "file_based_test_driver/base/ret_check.h"
 
 namespace file_based_test_driver {
@@ -102,8 +102,8 @@ absl::Status AlternationSetWithModes::Record(
     const std::string& alternation_name,
     const RunTestCaseWithModesResult& test_case_result) {
   FILE_BASED_TEST_DRIVER_RET_CHECK(!finished_);
-  static LazyRE2 re = {"[\\n\\{\\}\\<\\>]"};
-  FILE_BASED_TEST_DRIVER_RET_CHECK(!RE2::PartialMatch(alternation_name, *re))
+  static re2_st::LazyRE2 re = {"[\\n\\{\\}\\<\\>]"};
+  FILE_BASED_TEST_DRIVER_RET_CHECK(!re2_st::RE2::PartialMatch(alternation_name, *re))
       << "Alternation \"" << alternation_name << "\" contains names that can't "
       << "be stored in a result_type: " << re->pattern();
   alternations_.emplace_back(

--- a/file_based_test_driver/base/logging.cc
+++ b/file_based_test_driver/base/logging.cc
@@ -253,8 +253,6 @@ void LogMessage::SendToLog(const std::string &message_text) {
     fprintf(stderr, "%s\n", message_text.c_str());
     fflush(stderr);
   }
-  printf("%s\n", message_text.c_str());
-  fflush(stdout);
 }
 
 void LogMessage::Flush() {

--- a/file_based_test_driver/base/unified_diff_oss.cc
+++ b/file_based_test_driver/base/unified_diff_oss.cc
@@ -35,7 +35,7 @@
 #include "absl/strings/strip.h"
 #include "file_based_test_driver/base/diffchunk.h"
 #include "file_based_test_driver/base/rediff.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 
 namespace file_based_test_driver_base {
 

--- a/file_based_test_driver/file_based_test_driver.cc
+++ b/file_based_test_driver/file_based_test_driver.cc
@@ -72,7 +72,7 @@ ABSL_FLAG(int32_t, file_based_test_driver_stack_size_kb, 64,
 // Firebolt Start
 ABSL_FLAG(bool, fb_write_actual, true,
           "If true, a test failing in <testfile> will generate the actual"
-          "will generate the actual test result in <testfile>_actual.");
+          "test result in <testfile>_actual.");
 // Firebolt End
 
 namespace {

--- a/file_based_test_driver/file_based_test_driver.h
+++ b/file_based_test_driver/file_based_test_driver.h
@@ -199,8 +199,8 @@
 
 // Firebolt Start
 //
-// We are only exposing one custom flags here to minimize the risk of
-// shooting yourself in the foot:
+// We are only exposing one custom flag here to minimize the risk of
+// shooting ourselves in the foot:
 //
 // write_actual_result_files (default true)
 //    For tests that fail in the <testfile>, we write the actual result

--- a/file_based_test_driver/file_based_test_driver.h
+++ b/file_based_test_driver/file_based_test_driver.h
@@ -197,17 +197,16 @@
 #include "absl/strings/string_view.h"
 #include "file_based_test_driver/run_test_case_result.h"
 
-// Set this flag to a positive value to force each test case to start with a
-// particular number of blank lines.
-ABSL_DECLARE_FLAG(int32_t, file_based_test_driver_insert_leading_blank_lines);
-
-// Set this flag to replace all substrings matching this pattern with a fixed
-// string on a copy of the expected output and generated output for diffing.
-ABSL_DECLARE_FLAG(std::string, file_based_test_driver_ignore_regex);
-
-// Set this flag to enable calling EXPECT_EQ on every diff. This enables
-// displaying individual diff failures in sponge.
-ABSL_DECLARE_FLAG(bool, file_based_test_driver_individual_tests);
+// Firebolt Start
+//
+// We are only exposing one custom flags here to minimize the risk of
+// shooting yourself in the foot:
+//
+// write_actual_result_files (default true)
+//    For tests that fail in the <testfile>, we write the actual result
+//    into a file called <testfile>_actual.
+ABSL_DECLARE_FLAG(bool, fb_write_actual);
+// Firebolt End
 
 namespace file_based_test_driver {
 

--- a/file_based_test_driver/test_case_mode.cc
+++ b/file_based_test_driver/test_case_mode.cc
@@ -27,7 +27,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 #include "file_based_test_driver/base/status_macros.h"
 
 namespace file_based_test_driver {
@@ -40,13 +40,13 @@ file_based_test_driver_base::StatusOr<TestCaseMode> TestCaseMode::Create(
       return ::file_based_test_driver_base::FailedPreconditionErrorBuilder()
              << "Multi-part modes cannot contain empty strings";
     }
-    static LazyRE2 whitespace = {"\\s"};
-    if (RE2::PartialMatch(part, *whitespace)) {
+    static re2_st::LazyRE2 whitespace = {"\\s"};
+    if (re2_st::RE2::PartialMatch(part, *whitespace)) {
       return ::file_based_test_driver_base::FailedPreconditionErrorBuilder()
              << "Multi-part modes cannot contain spaces";
     }
-    static LazyRE2 literal_star = {"\\*"};
-    if (RE2::PartialMatch(part, *literal_star)) {
+    static re2_st::LazyRE2 literal_star = {"\\*"};
+    if (re2_st::RE2::PartialMatch(part, *literal_star)) {
       return ::file_based_test_driver_base::FailedPreconditionErrorBuilder()
              << "Multi-part modes cannot contain literal stars (*)";
     }

--- a/file_based_test_driver/test_case_outputs.cc
+++ b/file_based_test_driver/test_case_outputs.cc
@@ -33,7 +33,7 @@
 #include "absl/strings/strip.h"
 #include "file_based_test_driver/test_case_mode.h"
 #include "file_based_test_driver/base/map_util.h"
-#include "re2/re2.h"
+#include "re2_st/re2.h"
 #include "file_based_test_driver/base/ret_check.h"
 #include "file_based_test_driver/base/status_macros.h"
 
@@ -93,7 +93,7 @@ absl::Status ParseFirstLine(const absl::string_view part,
   } else {
     result->is_possible_modes = false;
     // TODO: Support [\n{}<>] in alternation modes with escaping.
-    if (!RE2::FullMatch(stripped_first_line, "^<([^>]*)>(.*)",
+    if (!re2_st::RE2::FullMatch(stripped_first_line, "^<([^>]*)>(.*)",
                         &result->result_type, &test_modes_sp)) {
       return absl::OkStatus();
     }


### PR DESCRIPTION
Improve Ease of Use for Wrong Results

At the moment, the file-based text driver has a few problems:
- It dumps a crazy amount of text to stdout, even if everything goes
  right.
- It does not make it very easy to see what exactly failed. This is
  especially true for long text files with many test cases.

This PR is a rather hacky approach to solve our biggest problems with
this:
- We still write extensive logs into /tmp/file_based_text_driver.
- We only dump things to stdout when tests fail. In that case we write
  out both the expected result, as well as the actual one.
- If a test fails, we create a <textfile>_actual file containing context
  on the failed tests, as well as the exact diff.