### PR TITLE
Make fb_write_actual to actually produce actual results

### DIFF
--- a/file_based_test_driver/file_based_test_driver.cc
+++ b/file_based_test_driver/file_based_test_driver.cc
@@ -385,17 +385,17 @@ static bool CompareAndAppendOutput(
 
     // Write results to the file.
     actual.open(std::string(filename) + "_actual", mode);
+    if (!all_output->empty()) {
+      actual << "==\n";
+    }
+    actual << output_string;
+    actual.close();
   }
   // Firebolt End
 
   // Add to all_output.
   if (!all_output->empty()) {
     absl::StrAppend(all_output, "==\n");
-    // Firebolt Start
-    if (absl::GetFlag(FLAGS_fb_write_actual)) {
-      actual << "==\n";
-    }
-    // Firebolt End
   }
   if (matches_requested_same_as_previous) {
     absl::StrAppend(all_output,
@@ -404,12 +404,6 @@ static bool CompareAndAppendOutput(
   } else {
     absl::StrAppend(all_output, output_string);
   }
-  // Firebolt Start
-  if (absl::GetFlag(FLAGS_fb_write_actual)) {
-    actual << output_string;
-    actual.close();
-  }
-  // Firebolt End
 
   return found_diffs;
 }

--- a/file_based_test_driver/file_based_test_driver.cc
+++ b/file_based_test_driver/file_based_test_driver.cc
@@ -394,9 +394,7 @@ static bool CompareAndAppendOutput(
   // Firebolt End
 
   // Add to all_output.
-  if (!all_output->empty()) {
-    absl::StrAppend(all_output, "==\n");
-  }
+  if (!all_output->empty()) absl::StrAppend(all_output, "==\n");
   if (matches_requested_same_as_previous) {
     absl::StrAppend(all_output,
                     internal::BuildTestFileEntry(


### PR DESCRIPTION
Make FileBasedTestDriver to actually print the actual result for all tests (and not diffs for failures) into _actual file when fb_write_actual flag is set.

Then user can diff _actual file with the original and see diffs for herself, or even use this as mechanism to generate results and simply copy _actual file over.