### PR TITLE
feat(FIR-25191): output_has_header option for better comparison with unsorted_output

### DIFF
--- a/file_based_test_driver/alternations.cc
+++ b/file_based_test_driver/alternations.cc
@@ -33,7 +33,7 @@ absl::Status AlternationSet::Record(const std::string& alternation_name,
   if (test_case_result.compare_unsorted_result()) {
     // test_outputs.size() > 1 if there are multiple outputs per alternation.
     for (std::string& output : test_outputs) {
-      output = SortLines(output);
+      output = SortLines(output, test_case_result.output_has_header());
     }
   }
   alternation_map_[test_outputs].push_back(alternation_names_.size());

--- a/file_based_test_driver/file_based_test_driver.h
+++ b/file_based_test_driver/file_based_test_driver.h
@@ -292,7 +292,7 @@ int64_t CountTestCasesInFiles(absl::string_view filespec);
 
 // Firebolt Start
 // Returns a string with all the lines in s sorted lexicographically.
-std::string SortLines(absl::string_view s);
+std::string SortLines(absl::string_view s, bool skip_header);
 // Firebolt End
 
 // Internal functions. Exposed here for unit testing purposes only, do not use

--- a/file_based_test_driver/run_test_case_result.h
+++ b/file_based_test_driver/run_test_case_result.h
@@ -81,6 +81,11 @@ class RunTestCaseResultBase {
   void set_compare_unsorted_result(bool compare_unsorted_result) {
     compare_unsorted_result_ = compare_unsorted_result;
   }
+
+  bool output_has_header() const { return output_has_header_; }
+  void set_output_has_header(bool output_has_header) {
+    output_has_header_ = output_has_header;
+  }
   // Firebolt End
 
  private:
@@ -102,6 +107,9 @@ class RunTestCaseResultBase {
   // result even if the order of the lines is different. Currently, this is
   // achieved by lexicographically sorting the lines before comparison.
   bool compare_unsorted_result_{false};
+  // If compare_unsorted_result_ is true, decide whether first line of the
+  // result is a header, and hence doesn't need to be sorted
+  bool output_has_header_{false};
   // Firebolt End
 };
 


### PR DESCRIPTION
## Summary

We use `[unsorted_output]` to compare results of queries which produce multiple rows, e.g. in `sql_test`

```
[unsorted_output]
select * from unnest([1,5,2] x) 
--
x INTEGER
1
5
2
```

The problem is that since [unsorted_output] just sorts all the lines in the output, the header row which is produced by `TestTextOutput` formatter ends up at the end:

```
1
2
5
x INTEGER
```

which is really inconvinient. So we add an option (which will be automatically triggered by `sql_test` for `TestTextOutput` and other formats with header row) - called output_has_header, which tells file based driver not to sort the first row, so the result will end up being:

```
x INTEGER
1
2
5
```

## Test

I couldn't get bazel working on file-based-test-driver - so all the testing was done using sql_test, which will be visible in the followup PR to packdb.