### PR TITLE
feat(31365): Emit regex into actual file if it matched

### DIFF
--- a/file_based_test_driver/file_based_test_driver.cc
+++ b/file_based_test_driver/file_based_test_driver.cc
@@ -472,7 +472,7 @@ static bool CompareAndAppendOutput(
     if (!all_output->empty()) {
       actual << "==\n";
     }
-    actual << output_string;
+    actual << (found_diffs ? output_string : expected_string);
     actual.close();
   }
   // Firebolt End
@@ -484,7 +484,7 @@ static bool CompareAndAppendOutput(
                     internal::BuildTestFileEntry(
                         {test_string, "[SAME AS PREVIOUS]\n"}, *comments));
   } else {
-    absl::StrAppend(all_output, output_string);
+    absl::StrAppend(all_output, found_diffs ? output_string : expected_string);
   }
 
   return found_diffs;


### PR DESCRIPTION
# Summary
At the moment, the option `output_is_regex` makes diffing test files to actual files more difficult, because the actual files contain the output of the command instead of the regex even if the regex matched the output. 

This PR changes the behavior to emitting the regex into the actual file if the output matched. It makes the diff cleaner in the presence of tests with `output_is_regex` enabled.

# Test Plan
Tested with `sql_test` in `packdb`. Once this PR is merged, I will create a follow-up PR that updates the submodule commit in `packdb`. 